### PR TITLE
Fix existing pipeline

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Run nginx container
       run: |
         docker run -tid --name nodeundertest host2test
-        sleep 3
+        sleep 9
         docker cp nodeundertest:/etc/ssl/certs/nginx-selfsigned.crt .
         echo "=========PRINTING CERT==========="
         cat nginx-selfsigned.crt

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -80,6 +80,7 @@ jobs:
     - name: Run nginx container
       run: |
         docker run -tid --name nodeundertest host2test
+        sleep 3
         docker cp nodeundertest:/etc/ssl/certs/nginx-selfsigned.crt .
         echo "=========PRINTING CERT==========="
         cat nginx-selfsigned.crt

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -80,11 +80,6 @@ jobs:
     - name: Run nginx container
       run: |
         docker run -tid --name nodeundertest host2test
-        sleep 9
-        docker cp nodeundertest:/etc/ssl/certs/nginx-selfsigned.crt .
-        echo "=========PRINTING CERT==========="
-        cat nginx-selfsigned.crt
-        echo "==========PRINTED CERT==========="
 
     - name: Stub out send_email function
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -83,11 +83,11 @@ jobs:
 
     - name: Stub out send_email function
       run: |
-        sed -i "/def send_email(msg: EmailMessage, email_from_addy: str, password: str)/,/smtp.quit()/cdef send_email(msg: EmailMessage, email_from_addy: str, password: str): raise RuntimeError(msg)" generalised_functions.py
+        sed -i "/def send_email(msg: EmailMessage, email_from_addy: str, password: str)/,/smtp.quit()/cdef send_email(msg: EmailMessage, email_from_addy: str, password: str): raise RuntimeError(msg)" indie_gen_funcs.py
 
     - name: Check send_email function stubbed
       run: |
-        cat generalised_functions.py | grep -A10 "def send_email"
+        cat indie_gen_funcs.py | grep -A10 "def send_email"
 
     - name: Test probing nginx HTTP
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -94,7 +94,9 @@ jobs:
         cont_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nodeundertest)
         sed -iE "s/172.17.0.2/$cont_ip/g" tests/sample_config.json
         sed -iE "s|\"home_page\": .*|\"home_page\": \"http://$cont_ip/\"|" tests/sample_config.json
+        echo "beginning python test"
         ./server_mon.py -n tests/sample_config.json email_agent_addy@gmail.com email_agent_password
+        echo "finished python test"
         tail -n1 results/node_*.csv
         http_code=$(tail -n1 results/node_*.csv | cut -d "," -f 6)
         if [ $http_code != "200" ]; then
@@ -120,7 +122,13 @@ jobs:
         cont_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nodeundertest)
         sed -iE '/"ip":/a\        "verify": "nginx-selfsigned.crt",' tests/sample_config.json
         sed -iE "s|\"home_page\": .*\"|\"home_page\": \"http://$cont_ip/provisioned.html\"|" tests/sample_config.json
+        echo "=========PRINTING CONF==========="
+        cat tests/sample_config.json
+        echo "==========PRINTED CONF==========="
         docker cp nodeundertest:/etc/ssl/certs/nginx-selfsigned.crt .
+        echo "=========PRINTING CERT==========="
+        cat nginx-selfsigned.crt
+        echo "==========PRINTED CERT==========="
         ./server_mon.py -n tests/sample_config.json email_agent_addy@gmail.com email_agent_password
         tail -n1 results/node_*.csv
         http_code=$(tail -n1 results/node_*.csv | cut -d "," -f 6)

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -80,6 +80,10 @@ jobs:
     - name: Run nginx container
       run: |
         docker run -tid --name nodeundertest host2test
+        docker cp nodeundertest:/etc/ssl/certs/nginx-selfsigned.crt .
+        echo "=========PRINTING CERT==========="
+        cat nginx-selfsigned.crt
+        echo "==========PRINTED CERT==========="
 
     - name: Stub out send_email function
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest coverage
+        pip install flake8 pytest coverage ansible
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Lint with flake8
@@ -93,6 +93,7 @@ jobs:
       run: |
         cont_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nodeundertest)
         sed -iE "s/172.17.0.2/$cont_ip/g" tests/sample_config.json
+        # Prior to our provisioning, the container defaults to serving '/'
         sed -iE "s|\"home_page\": .*|\"home_page\": \"http://$cont_ip/\"|" tests/sample_config.json
         echo "beginning python test"
         ./server_mon.py -n tests/sample_config.json email_agent_addy@gmail.com email_agent_password
@@ -105,7 +106,7 @@ jobs:
 
 
 
-    - name: Provision nginx container
+    - name: Provision nginx container to use TLS
       run: |
         cont_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nodeundertest)
         cd pb_provisioner
@@ -122,13 +123,8 @@ jobs:
         cont_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' nodeundertest)
         sed -iE '/"ip":/a\        "verify": "nginx-selfsigned.crt",' tests/sample_config.json
         sed -iE "s|\"home_page\": .*\"|\"home_page\": \"http://$cont_ip/provisioned.html\"|" tests/sample_config.json
-        echo "=========PRINTING CONF==========="
-        cat tests/sample_config.json
-        echo "==========PRINTED CONF==========="
         docker cp nodeundertest:/etc/ssl/certs/nginx-selfsigned.crt .
-        echo "=========PRINTING CERT==========="
-        cat nginx-selfsigned.crt
-        echo "==========PRINTED CERT==========="
+        openssl x509 -text -noout -in nginx-selfsigned.crt
         ./server_mon.py -n tests/sample_config.json email_agent_addy@gmail.com email_agent_password
         tail -n1 results/node_*.csv
         http_code=$(tail -n1 results/node_*.csv | cut -d "," -f 6)

--- a/build_directory/Dockerfile
+++ b/build_directory/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20221004-slim
+FROM debian:bookworm-20230703-slim
 
 ENV newusername=testrunner
 

--- a/generalised_functions.py
+++ b/generalised_functions.py
@@ -1,334 +1,14 @@
 from __future__ import annotations
 
-import argparse
-import os
-
-import requests
-from datetime import datetime
 import json
-import smtplib
-import traceback
-from email.message import EmailMessage
-from pathlib import Path
-from typing import List, Dict, Optional, Any, Callable, Union
+from typing import List, Callable
 
+import indie_gen_funcs
 from check_result import CheckResult
-from html_tabulating import tabulate_csv_as_html
+from indie_gen_funcs import ErrorHandler, ResultHolder, parse_args_for_monitoring, email_wout_further_checks, \
+    compose_email, send_email, monitor_runners_ipv4, DAY_TIME_FMT
+from interrog_routines import interrog_routine
 from ping_functions import get_ping_latencies
-
-
-_MONITOR_EMAIL = "insert_email_here.Can_be_read_from_json_config."
-PUBLIC_IP = "where we test from. Can be read from json config."
-RESULTS_DIR = "results"
-DATE_MON_FMT = "%y%m"
-DAY_TIME_FMT = "%d %H:%M:%S"
-
-
-def send_email(msg: EmailMessage, email_from_addy: str, password: str):
-    """
-    EmailMessage will already contain particular fields, such as "subject".
-    This function just uses an account to actually send it.
-
-    To help keep your account secure, from **May 30, 2022**, Google no longer
-    supports the use of third-party apps or devices which ask you to sign in
-    to your Google Account using only your username and password.
-
-    Solution:
-        - Enable MFA
-        - Crete "App password" per app (this app)
-        - Use that password in place of your general password, I guess this
-            provides accountability as to who (or what password) logged in
-            as you.
-    """
-    # Use this account to send email to another:
-    msg["From"] = email_from_addy
-    # Attempt to make this work for other than gmail:
-    smtp_server = "smtp." + email_from_addy.split("@")[-1]
-    # 587 is the default TLS port we want to use:
-    smtp = smtplib.SMTP(smtp_server, 587)
-    try:
-        smtp.ehlo()
-        smtp.starttls()
-        smtp.ehlo()
-        smtp.login(msg["From"], password)
-        smtp.send_message(msg)
-    finally:
-        smtp.quit()
-
-
-def monitor_runners_ipv4():
-    """Keep a record of what IP we're on which might be useful in
-    whitelisting blocks for our future access to these servers."""
-    runners_ip = get_public_ip()
-    Path(RESULTS_DIR).mkdir(parents=True, exist_ok=True)
-    try:
-        with open(f"{RESULTS_DIR}/public_ip_history.txt") as f:
-            lines = f.read().splitlines()
-            last_ip = lines[-1]
-    except FileNotFoundError:
-        last_ip = ""
-    if last_ip != runners_ip:
-        with open(f"{RESULTS_DIR}/public_ip_history.txt", "a+") as f:
-            f.write(runners_ip)
-    global PUBLIC_IP
-    PUBLIC_IP = runners_ip
-
-
-def plural(quantity, extension="s"):
-    """
-    :param quantity: list or integer.
-    :param extension: how do extend to plural form.
-    :return: plural extension if required.
-    """
-    if type(quantity) == list:
-        count = len(quantity)
-    elif type(quantity) == int:
-        count = quantity
-    else:
-        raise ValueError(
-            "Unexpected type {} of {}".format(type(quantity), quantity))
-    return extension if count != 1 else ""
-
-
-def convert_date_to_human_readable(date_str, date_formatter):
-    """
-    Standardises date string to show month, day, and time if year is same, else
-    year.
-    """
-    py_date = datetime.strptime(date_str, date_formatter)
-    if py_date.year == datetime.utcnow().year:
-        fstring = "%b %-d %H:%M"
-    else:
-        fstring = "%b %-d %Y"
-    if os.name == 'nt':
-        fstring = fstring.replace("-", "#")
-    return "{} {:>2} {}".format(*py_date.strftime(fstring).split(" "))
-
-
-def find_cells_under(table_lines: List[str], col_header: str) -> List[str]:
-    """
-    Intended for ss lines. Assumes cell will be populated in each row
-    (otherwise we overflow into next cell.)
-    """
-    col_indent = table_lines[0].find(col_header)
-    cells = []
-    for row in table_lines[1:]:
-        cell_i = col_indent
-        if row[cell_i] == " ":
-            # advance to content:
-            while row[cell_i] == " ":
-                cell_i += 1
-        else:
-            # reverse to start of wider content:
-            while row[cell_i] != " ":
-                cell_i -= 1
-            cell_i += 1  # jump to start of word
-        cells.append(row[cell_i:].split()[0])
-    return cells
-
-
-class ErrorHandler:
-    """
-    Collects errors and indexes them as lists under the failing server's
-    IP address.
-    """
-    def __init__(self):
-        self.errors: Dict[str, List[Union[Exception, str]]] = {}
-        self.msg = EmailMessage()
-        self.msg["To"] = _MONITOR_EMAIL
-        # Frame of reference for assigned stack traces:
-        self.current_ip: Optional[str] = None
-        self.first_error: Optional[Exception] = None
-        self.first_ip: Optional[str] = None
-
-    def append(self, error: Union[Exception, str]):
-        if self.first_error is None:
-            self.first_error = error
-            self.first_ip = self.current_ip
-        self.errors.setdefault(self.current_ip, []).append(error)
-
-    def set_subject(self, unit_name: str):
-        """
-        This is not expected to be called when there are no errors to send.
-        """
-        subject = str(self.first_error)
-        err_cnt = sum([len(x) for x in self.errors.values()])
-        node_cnt = len(self.errors.keys())
-        try:
-            # Handle unknown errors:
-            subject = "{} error{} on {} (failing) {}{}, first at {}: {}".format(
-                err_cnt, plural(err_cnt), node_cnt, unit_name, plural(node_cnt),
-                self.first_ip, self.first_error)
-        except Exception as e:
-            subject += "==Error setting subject, {}==".format(e)
-        self.msg["Subject"] = subject
-
-    def email_traces(self, email_addy: str, password: str, unit_name: str):
-        """Sends all error information held."""
-        self.set_subject(unit_name)
-        message = ""
-        for ip in self.errors.keys():
-            message += "================\n{}\n".format(ip)
-            for error in self.errors[ip]:
-                if isinstance(error, Exception):
-                    message += ''.join(traceback.format_exception(
-                        type(error), value=error, tb=error.__traceback__))
-                    message += '\n\n'
-                else:
-                    message += f"{error}\n\n"
-            message += "================\n\n"
-        self.msg.set_content(message)
-
-        send_email(self.msg, email_addy, password)
-
-
-class ResultHolder:
-    """
-    A class to hold check results in a list until they are ready for persisting.
-    """
-
-    def __init__(self):
-        self.results: List[CheckResult] = []
-        # Ideally all net operations should be done from a thread pool at once:
-        self.time = datetime.utcnow()
-
-    def append(self, result: CheckResult):
-        self.results.append(result)
-
-    def save(self, unit_name: str):
-        Path(RESULTS_DIR).mkdir(parents=True, exist_ok=True)
-        file_name = "{}/{}_{}.csv".format(
-            RESULTS_DIR, unit_name, self.time.strftime(DATE_MON_FMT))
-        with open(file_name, "a+") as f:
-            for result in self.results:
-                f.write(result.to_csv())
-
-
-def compose_email(
-        results: List, recipient: str, csv_header: str,
-        server_description: str, description: str) -> EmailMessage:
-    """
-    Composes an email about node Check Statuses.
-
-    :param results: list to put in email
-    :param recipient: who to send to
-    :param csv_header:
-    :param server_description: adding this info to the subject, is the server
-        a general node or specialist, like gpu?
-    :param description: typically at/on/for time_str
-    :return: EmailMessage
-    """
-    msg = EmailMessage()
-    msg["To"] = recipient
-    msg["Subject"] = "{} {} status{}{}".format(
-        len(results), server_description, plural(results, "es"), description)
-    ip_index = csv_header.split(",").index("ipv4")
-    # unlike a simple set, this maintains order since python 3.7:
-    distinct_ips = list(dict.fromkeys(
-        row.to_csv().split(",")[ip_index] for row in results))
-    results_by_ip = []
-    for ip in distinct_ips:
-        results_by_ip.append([row for row in results if row.to_csv().split(",")[ip_index] == ip])
-    content = []
-    for results_for_ip in results_by_ip:
-        content.append(tabulate_csv_as_html(csv_header, results_for_ip))
-    msg.set_content("\n<hr/>\n".join(content), subtype='html')
-    return msg
-
-
-def parse_args_for_monitoring(
-        args_list: List[str], unit_name: str) -> argparse.Namespace:
-    """
-    CLI useful to monitoring scripts. The beauty is in what said scripts do
-    with this info.
-
-    :param args_list: command line arguments
-    :param unit_name: so far we have "node" and "miner", describing what the
-        role of the monitored.
-    :return:
-    """
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=unit_name.capitalize() + """ monitoring script.
-
-Collects information on ping and http responses as well as some basic shell 
-commands over SSH.
-
-nodes_file is a list of servers with these fields:
-
-{
-  "servers": [
-    {
-      "ip": "21.151.211.10",
-      "creds": [
-        {
-          "username": "megamind",
-          "password": "fumbledpass",
-          "key_filename": "/home/megs/.ssh/id_rsa"
-        }
-      ],
-      "verify": "Optional path to public key or cert. True (default) or False to enable/disable.",
-      "home_page": "Used for HTTP(S) request, as health check / heartbeat. eg 'https://example.com'",
-      "ssh_peers": "IPv4 addresses of known, permitted ssh clients, separated by commas.",
-      "known_ports": "known, permitted listening ports, separated by commas."
-    }
-  ],
-  "email_dest": "email address to send notifications to."
-}
-""")
-    parser.add_argument(
-        "email_addy",
-        help="Email (gmail) account to use for sending error and "
-             "(optional) success emails.")
-    parser.add_argument(
-        "password",
-        help="Password for the provided email (gmail) address.")
-    parser.add_argument(
-        "-e", "--email_to",
-        help="Don't test, just email the month's log, to this address.")
-    parser.add_argument(
-        "-s", "--send_on_success",
-        help="Send an email upon success.", action="store_true")
-    parser.add_argument(
-        "-n", "--nodes_file",
-        help="Name of json file describing the nodes to monitor.",
-        default="monitored_{}s.json".format(unit_name))
-    args = parser.parse_args(args_list)
-    return args
-
-
-def load_results(
-        yymm: str, line_reader: Callable[[str], Any], unit_name: str) -> List:
-    """
-
-    :param yymm: can define the file being loaded, though now this is further
-        qualified according to the nature of tests and server.
-    :param line_reader: callback for processing each line read from the loaded
-        file.
-    :param unit_name: Used to separate results according to unit, or node, name
-        or type.
-    :return:
-    """
-    file_name = "{}/{}_{}.csv".format(RESULTS_DIR, unit_name, yymm)
-    results = []
-    with open(file_name, "r") as f:
-        lines = f.readlines()
-        for line in lines:
-            results.append(line_reader(line))
-    return results
-
-
-def email_wout_further_checks(
-        email_to: str, sender_addy: str, sender_pw: str,
-        check_result: CheckResult):
-    yymm = datetime.utcnow().strftime(DATE_MON_FMT)
-    results = load_results(
-        yymm, check_result.result_from_csv, check_result.get_unit_name())
-    msg = compose_email(
-        results, email_to, check_result.get_header(),
-        check_result.get_unit_name(), " for {}".format(yymm))
-    send_email(msg, sender_addy, sender_pw)
-
 
 IInterrogator = Callable[
     [ErrorHandler, dict, ResultHolder, str, List[str]], None]
@@ -336,14 +16,12 @@ IInterrogator = Callable[
 
 def process_args(
         args_list: List[str],
-        check_result: CheckResult,
-        interrog_routine: IInterrogator):
+        check_result: CheckResult):
     """
     Parses and processes command line arguments for monitoring scripts.
 
     :param args_list: command line args.
     :param check_result: a concrete dataclass of the abstract result holder.
-    :param interrog_routine: called if ping responds and we want more results.
     :return:
     """
     args = parse_args_for_monitoring(args_list, check_result.get_unit_name())
@@ -360,7 +38,7 @@ def process_args(
     result_holder.save(check_result.get_unit_name())
     if args.send_on_success:
         msg = compose_email(
-            result_holder.results, _MONITOR_EMAIL, check_result.get_header(),
+            result_holder.results, indie_gen_funcs._MONITOR_EMAIL, check_result.get_header(),
             check_result.get_unit_name(), "")
         send_email(msg, args.email_addy, args.password)
 
@@ -386,8 +64,7 @@ def iterate_rmt_servers(
     # Open nodes files from outside source control (don't commit credentials):
     with open(nodes_file_name, encoding="utf8") as f:
         config = json.load(f)
-    global _MONITOR_EMAIL
-    _MONITOR_EMAIL = config.get("email_dest", _MONITOR_EMAIL)
+    indie_gen_funcs._MONITOR_EMAIL = config.get("email_dest", indie_gen_funcs._MONITOR_EMAIL)
     err_handler = ErrorHandler()
     monitor_runners_ipv4()
 
@@ -403,8 +80,3 @@ def iterate_rmt_servers(
                 err_handler, rmt_pc, result_holder, ipv4, latencies)
     return err_handler
 
-
-def get_public_ip() -> str:
-    res = requests.get("http://ipinfo.io")
-    jres = res.json()
-    return jres["ip"]

--- a/indie_gen_funcs.py
+++ b/indie_gen_funcs.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import argparse
+import os
+import smtplib
+import traceback
+from datetime import datetime
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Any, Callable
+from typing import Dict, List, Union, Optional
+
+import requests
+
+from check_result import CheckResult
+from html_tabulating import tabulate_csv_as_html
+
+_MONITOR_EMAIL = "insert_email_here.Can_be_read_from_json_config."
+PUBLIC_IP = "where we test from. Can be read from json config."
+RESULTS_DIR = "results"
+DATE_MON_FMT = "%y%m"
+DAY_TIME_FMT = "%d %H:%M:%S"
+
+
+def send_email(msg: EmailMessage, email_from_addy: str, password: str):
+    """
+    EmailMessage will already contain particular fields, such as "subject".
+    This function just uses an account to actually send it.
+
+    To help keep your account secure, from **May 30, 2022**, Google no longer
+    supports the use of third-party apps or devices which ask you to sign in
+    to your Google Account using only your username and password.
+
+    Solution:
+        - Enable MFA
+        - Crete "App password" per app (this app)
+        - Use that password in place of your general password, I guess this
+            provides accountability as to who (or what password) logged in
+            as you.
+    """
+    # Use this account to send email to another:
+    msg["From"] = email_from_addy
+    # Attempt to make this work for other than gmail:
+    smtp_server = "smtp." + email_from_addy.split("@")[-1]
+    # 587 is the default TLS port we want to use:
+    smtp = smtplib.SMTP(smtp_server, 587)
+    try:
+        smtp.ehlo()
+        smtp.starttls()
+        smtp.ehlo()
+        smtp.login(msg["From"], password)
+        smtp.send_message(msg)
+    finally:
+        smtp.quit()
+
+
+def get_public_ip() -> str:
+    res = requests.get("http://ipinfo.io")
+    jres = res.json()
+    return jres["ip"]
+
+
+def monitor_runners_ipv4():
+    """Keep a record of what IP we're on which might be useful in
+    whitelisting blocks for our future access to these servers."""
+    runners_ip = get_public_ip()
+    Path(RESULTS_DIR).mkdir(parents=True, exist_ok=True)
+    try:
+        with open(f"{RESULTS_DIR}/public_ip_history.txt") as f:
+            lines = f.read().splitlines()
+            last_ip = lines[-1]
+    except FileNotFoundError:
+        last_ip = ""
+    if last_ip != runners_ip:
+        with open(f"{RESULTS_DIR}/public_ip_history.txt", "a+") as f:
+            f.write(runners_ip)
+    global PUBLIC_IP
+    PUBLIC_IP = runners_ip
+
+
+def plural(quantity, extension="s"):
+    """
+    :param quantity: list or integer.
+    :param extension: how do extend to plural form.
+    :return: plural extension if required.
+    """
+    if type(quantity) == list:
+        count = len(quantity)
+    elif type(quantity) == int:
+        count = quantity
+    else:
+        raise ValueError(
+            "Unexpected type {} of {}".format(type(quantity), quantity))
+    return extension if count != 1 else ""
+
+
+def convert_date_to_human_readable(date_str, date_formatter):
+    """
+    Standardises date string to show month, day, and time if year is same, else
+    year.
+    """
+    py_date = datetime.strptime(date_str, date_formatter)
+    if py_date.year == datetime.utcnow().year:
+        fstring = "%b %-d %H:%M"
+    else:
+        fstring = "%b %-d %Y"
+    if os.name == 'nt':
+        fstring = fstring.replace("-", "#")
+    return "{} {:>2} {}".format(*py_date.strftime(fstring).split(" "))
+
+
+def find_cells_under(table_lines: List[str], col_header: str) -> List[str]:
+    """
+    Intended for ss lines. Assumes cell will be populated in each row
+    (otherwise we overflow into next cell.)
+    """
+    col_indent = table_lines[0].find(col_header)
+    cells = []
+    for row in table_lines[1:]:
+        cell_i = col_indent
+        if row[cell_i] == " ":
+            # advance to content:
+            while row[cell_i] == " ":
+                cell_i += 1
+        else:
+            # reverse to start of wider content:
+            while row[cell_i] != " ":
+                cell_i -= 1
+            cell_i += 1  # jump to start of word
+        cells.append(row[cell_i:].split()[0])
+    return cells
+
+
+class ResultHolder:
+    """
+    A class to hold check results in a list until they are ready for persisting.
+    """
+
+    def __init__(self):
+        self.results: List[CheckResult] = []
+        # Ideally all net operations should be done from a thread pool at once:
+        self.time = datetime.utcnow()
+
+    def append(self, result: CheckResult):
+        self.results.append(result)
+
+    def save(self, unit_name: str):
+        Path(RESULTS_DIR).mkdir(parents=True, exist_ok=True)
+        file_name = "{}/{}_{}.csv".format(
+            RESULTS_DIR, unit_name, self.time.strftime(DATE_MON_FMT))
+        with open(file_name, "a+") as f:
+            for result in self.results:
+                f.write(result.to_csv())
+
+
+def compose_email(
+        results: List, recipient: str, csv_header: str,
+        server_description: str, description: str) -> EmailMessage:
+    """
+    Composes an email about node Check Statuses.
+
+    :param results: list to put in email
+    :param recipient: who to send to
+    :param csv_header:
+    :param server_description: adding this info to the subject, is the server
+        a general node or specialist, like gpu?
+    :param description: typically at/on/for time_str
+    :return: EmailMessage
+    """
+    msg = EmailMessage()
+    msg["To"] = recipient
+    msg["Subject"] = "{} {} status{}{}".format(
+        len(results), server_description, plural(results, "es"), description)
+    ip_index = csv_header.split(",").index("ipv4")
+    # unlike a simple set, this maintains order since python 3.7:
+    distinct_ips = list(dict.fromkeys(
+        row.to_csv().split(",")[ip_index] for row in results))
+    results_by_ip = []
+    for ip in distinct_ips:
+        results_by_ip.append([row for row in results if row.to_csv().split(",")[ip_index] == ip])
+    content = []
+    for results_for_ip in results_by_ip:
+        content.append(tabulate_csv_as_html(csv_header, results_for_ip))
+    msg.set_content("\n<hr/>\n".join(content), subtype='html')
+    return msg
+
+
+def parse_args_for_monitoring(
+        args_list: List[str], unit_name: str) -> argparse.Namespace:
+    """
+    CLI useful to monitoring scripts. The beauty is in what said scripts do
+    with this info.
+
+    :param args_list: command line arguments
+    :param unit_name: so far we have "node" and "miner", describing what the
+        role of the monitored.
+    :return:
+    """
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=unit_name.capitalize() + """ monitoring script.
+
+Collects information on ping and http responses as well as some basic shell 
+commands over SSH.
+
+nodes_file is a list of servers with these fields:
+
+{
+  "servers": [
+    {
+      "ip": "21.151.211.10",
+      "creds": [
+        {
+          "username": "megamind",
+          "password": "fumbledpass",
+          "key_filename": "/home/megs/.ssh/id_rsa"
+        }
+      ],
+      "verify": "Optional path to public key or cert. True (default) or False to enable/disable.",
+      "home_page": "Used for HTTP(S) request, as health check / heartbeat. eg 'https://example.com'",
+      "ssh_peers": "IPv4 addresses of known, permitted ssh clients, separated by commas.",
+      "known_ports": "known, permitted listening ports, separated by commas."
+    }
+  ],
+  "email_dest": "email address to send notifications to."
+}
+""")
+    parser.add_argument(
+        "email_addy",
+        help="Email (gmail) account to use for sending error and "
+             "(optional) success emails.")
+    parser.add_argument(
+        "password",
+        help="Password for the provided email (gmail) address.")
+    parser.add_argument(
+        "-e", "--email_to",
+        help="Don't test, just email the month's log, to this address.")
+    parser.add_argument(
+        "-s", "--send_on_success",
+        help="Send an email upon success.", action="store_true")
+    parser.add_argument(
+        "-n", "--nodes_file",
+        help="Name of json file describing the nodes to monitor.",
+        default="monitored_{}s.json".format(unit_name))
+    args = parser.parse_args(args_list)
+    return args
+
+
+def load_results(
+        yymm: str, line_reader: Callable[[str], Any], unit_name: str) -> List:
+    """
+
+    :param yymm: can define the file being loaded, though now this is further
+        qualified according to the nature of tests and server.
+    :param line_reader: callback for processing each line read from the loaded
+        file.
+    :param unit_name: Used to separate results according to unit, or node, name
+        or type.
+    :return:
+    """
+    file_name = "{}/{}_{}.csv".format(RESULTS_DIR, unit_name, yymm)
+    results = []
+    with open(file_name, "r") as f:
+        lines = f.readlines()
+        for line in lines:
+            results.append(line_reader(line))
+    return results
+
+
+def email_wout_further_checks(
+        email_to: str, sender_addy: str, sender_pw: str,
+        check_result: CheckResult):
+    yymm = datetime.utcnow().strftime(DATE_MON_FMT)
+    results = load_results(
+        yymm, check_result.result_from_csv, check_result.get_unit_name())
+    msg = compose_email(
+        results, email_to, check_result.get_header(),
+        check_result.get_unit_name(), " for {}".format(yymm))
+    send_email(msg, sender_addy, sender_pw)
+
+
+
+
+class ErrorHandler:
+    """
+    Collects errors and indexes them as lists under the failing server's
+    IP address.
+    """
+    def __init__(self):
+        self.errors: Dict[str, List[Union[Exception, str]]] = {}
+        self.msg = EmailMessage()
+        self.msg["To"] = _MONITOR_EMAIL
+        # Frame of reference for assigned stack traces:
+        self.current_ip: Optional[str] = None
+        self.first_error: Optional[Exception] = None
+        self.first_ip: Optional[str] = None
+
+    def append(self, error: Union[Exception, str]):
+        if self.first_error is None:
+            self.first_error = error
+            self.first_ip = self.current_ip
+        self.errors.setdefault(self.current_ip, []).append(error)
+
+    def set_subject(self, unit_name: str):
+        """
+        This is not expected to be called when there are no errors to send.
+        """
+        subject = str(self.first_error)
+        err_cnt = sum([len(x) for x in self.errors.values()])
+        node_cnt = len(self.errors.keys())
+        try:
+            # Handle unknown errors:
+            subject = "{} error{} on {} (failing) {}{}, first at {}: {}".format(
+                err_cnt, plural(err_cnt), node_cnt, unit_name, plural(node_cnt),
+                self.first_ip, self.first_error)
+        except Exception as e:
+            subject += "==Error setting subject, {}==".format(e)
+        self.msg["Subject"] = subject
+
+    def email_traces(self, email_addy: str, password: str, unit_name: str):
+        """Sends all error information held."""
+        self.set_subject(unit_name)
+        message = ""
+        for ip in self.errors.keys():
+            message += "================\n{}\n".format(ip)
+            for error in self.errors[ip]:
+                if isinstance(error, Exception):
+                    message += ''.join(traceback.format_exception(
+                        type(error), value=error, tb=error.__traceback__))
+                    message += '\n\n'
+                else:
+                    message += f"{error}\n\n"
+            message += "================\n\n"
+        self.msg.set_content(message)
+
+        send_email(self.msg, email_addy, password)

--- a/interrog_routines.py
+++ b/interrog_routines.py
@@ -18,7 +18,6 @@ def interrog_routine(err_handler: ErrorHandler, rmt_pc: dict,
     try:
         resp = requests.get(rmt_pc["home_page"], timeout=5, verify=rmt_pc.get("verify", True))
     except SSLError as ssl_e:
-        print("We are good, right?")
         err_handler.append(ssl_e)
         resp = requests.get(rmt_pc["home_page"], timeout=5, verify=False)
     except requests.exceptions.ConnectionError as awol_e:

--- a/interrog_routines.py
+++ b/interrog_routines.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import List
+
+import requests
+from requests.exceptions import SSLError
+
+from check_result import CheckResult
+from indie_gen_funcs import ErrorHandler, ResultHolder, DAY_TIME_FMT
+from paramiko_client import SSHInterrogator
+
+
+def interrog_routine(err_handler: ErrorHandler, rmt_pc: dict,
+                     result_holder: ResultHolder,
+                     ipv4: str, latencies: List[str]):
+    ave_latency_ms = str(int(round(sum(map(float, latencies)) / len(latencies))))
+    max_latency_ms = str(int(round(max(map(float, latencies)))))
+    try:
+        resp = requests.get(rmt_pc["home_page"], timeout=5, verify=rmt_pc.get("verify", True))
+    except SSLError as ssl_e:
+        print("We are good, right?")
+        err_handler.append(ssl_e)
+        resp = requests.get(rmt_pc["home_page"], timeout=5, verify=False)
+    except requests.exceptions.ConnectionError as awol_e:
+        # We failed. Not merely on TLS but the whole HTTP(S) response.
+        err_handler.append(awol_e)
+        # That will send us a whole, overly long, stack trace, later.
+        return
+    response_ms = str(int(round(1000 * resp.elapsed.total_seconds()))) \
+        if resp.ok else None
+    ssh_interrogator = SSHInterrogator(err_handler)
+    ssh_interrogator.do_queries(rmt_pc)
+    result_holder.append(CheckResult(
+        result_holder.time.strftime(DAY_TIME_FMT), ipv4, ave_latency_ms,
+        max_latency_ms, response_ms, str(resp.status_code),
+        ssh_interrogator.mem_avail, ssh_interrogator.swap_free,
+        ssh_interrogator.disk_avail, ssh_interrogator.last_boot,
+        ssh_interrogator.ports, ssh_interrogator.ssh_peers
+    ))

--- a/paramiko_client.py
+++ b/paramiko_client.py
@@ -5,9 +5,10 @@ import paramiko
 from paramiko import SSHClient
 from paramiko.ssh_exception import AuthenticationException, BadHostKeyException
 
-from generalised_functions import ErrorHandler, find_cells_under, \
+from indie_gen_funcs import find_cells_under, \
     convert_date_to_human_readable
-import generalised_functions
+from indie_gen_funcs import ErrorHandler
+import indie_gen_funcs
 
 
 class SSHInterrogator:
@@ -65,7 +66,7 @@ class SSHInterrogator:
         self.query_boot_time()
         self.query_disk_free()
         ssh_peers = self.parse_user_csv(rmt_pc.get("ssh_peers", ""))
-        ssh_peers.add(generalised_functions.PUBLIC_IP)
+        ssh_peers.add(indie_gen_funcs.PUBLIC_IP)
         self.query_ssh_peers(ssh_peers)
         self.query_ports(self.parse_user_csv(rmt_pc.get("known_ports", "")))
 

--- a/pb_provisioner/provision_server.yml
+++ b/pb_provisioner/provision_server.yml
@@ -45,6 +45,7 @@
           cmd: >
             openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:prime256v1
             -days 365 -nodes -x509 -subj "/CN={{ domain_name }}"
+            -addext "subjectAltName = IP:{{ domain_name }}"
             -keyout "{{ tls_cert_key }}" -out "{{ tls_cert_file }}"
 
 

--- a/server_mon.py
+++ b/server_mon.py
@@ -29,6 +29,7 @@ def interrog_routine(err_handler: ErrorHandler, rmt_pc: dict,
     try:
         resp = requests.get(rmt_pc["home_page"], timeout=5, verify=rmt_pc.get("verify", True))
     except SSLError as ssl_e:
+        print("We are good, right?")
         err_handler.append(ssl_e)
         resp = requests.get(rmt_pc["home_page"], timeout=5, verify=False)
     except requests.exceptions.ConnectionError as awol_e:

--- a/server_mon.py
+++ b/server_mon.py
@@ -11,47 +11,13 @@ HTTP requests might best be observed without undue warning.
 """
 
 import sys
-from typing import Optional, List
+from typing import List
 
-import requests
-from requests.exceptions import SSLError
-
-from generalised_functions import ErrorHandler, ResultHolder,\
-    process_args, CheckResult, DAY_TIME_FMT
-from paramiko_client import SSHInterrogator
-
-
-def interrog_routine(err_handler: ErrorHandler, rmt_pc: dict,
-                     result_holder: ResultHolder,
-                     ipv4: str, latencies: List[str]):
-    ave_latency_ms = str(int(round(sum(map(float, latencies)) / len(latencies))))
-    max_latency_ms = str(int(round(max(map(float, latencies)))))
-    try:
-        resp = requests.get(rmt_pc["home_page"], timeout=5, verify=rmt_pc.get("verify", True))
-    except SSLError as ssl_e:
-        print("We are good, right?")
-        err_handler.append(ssl_e)
-        resp = requests.get(rmt_pc["home_page"], timeout=5, verify=False)
-    except requests.exceptions.ConnectionError as awol_e:
-        # We failed. Not merely on TLS but the whole HTTP(S) response.
-        err_handler.append(awol_e)
-        # That will send us a whole, overly long, stack trace, later.
-        return
-    response_ms = str(int(round(1000 * resp.elapsed.total_seconds()))) \
-        if resp.ok else None
-    ssh_interrogator = SSHInterrogator(err_handler)
-    ssh_interrogator.do_queries(rmt_pc)
-    result_holder.append(CheckResult(
-        result_holder.time.strftime(DAY_TIME_FMT), ipv4, ave_latency_ms,
-        max_latency_ms, response_ms, str(resp.status_code),
-        ssh_interrogator.mem_avail, ssh_interrogator.swap_free,
-        ssh_interrogator.disk_avail, ssh_interrogator.last_boot,
-        ssh_interrogator.ports, ssh_interrogator.ssh_peers
-    ))
+from generalised_functions import process_args, CheckResult
 
 
 def main(args_list: List[str]):
-    process_args(args_list, CheckResult, interrog_routine)
+    process_args(args_list, CheckResult)
 
 
 if __name__ == "__main__":

--- a/server_pinger.py
+++ b/server_pinger.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, List, Tuple
 
-from generalised_functions import RESULTS_DIR
+from indie_gen_funcs import RESULTS_DIR
 from check_result import format_ipv4
 from ping_functions import ping
 

--- a/tests/test_generalised_functions.py
+++ b/tests/test_generalised_functions.py
@@ -1,278 +1,9 @@
-import argparse
-import datetime
-import smtplib
-import traceback
-from email.message import EmailMessage
-from typing import List
-from unittest.mock import Mock, patch, call, sentinel, mock_open, create_autospec
+from unittest.mock import patch, sentinel, create_autospec
 
-import pytest
-
-from generalised_functions import find_cells_under, plural, \
-    send_email, get_public_ip, monitor_runners_ipv4, \
-    compose_email, parse_args_for_monitoring, CheckResult, \
-    email_wout_further_checks, load_results, RESULTS_DIR, \
-    ErrorHandler, _MONITOR_EMAIL, ResultHolder, DATE_MON_FMT, process_args, \
-    IInterrogator, iterate_rmt_servers, convert_date_to_human_readable
-from check_result import format_ipv4
-
-
-def test_easy_find_cells_under(ss_lines_1):
-    # Here we have cells both inside and outside of the column headers.
-    cells = find_cells_under(ss_lines_1, "Local Address:Port")
-    assert cells == ["42.8.101.220:22", "42.8.101.220:22", "42.8.101.220:22"]
-    cells = find_cells_under(ss_lines_1, "Peer Address:Port")
-    assert cells == ["121.44.111.12:45900", "61.177.173.18:51931", "222.186.30.112:61668"]
-
-
-def test_harder_find_cells_under(ss_lines_2):
-    # Here we have the more extreme case where the columns are cramped (as far as they go without wrapping).
-    # This causes problems because taking a delimiter of 1 space splits some column headers.
-    # I would like to unlimit the pty width in paramiko.
-    cells = find_cells_under(ss_lines_2, "Local Address:Port")
-    assert cells == ["42.8.101.220:22", "42.8.101.220:22", "42.8.101.220:22", "42.8.101.220:22"]
-    cells = find_cells_under(ss_lines_2, "Peer Address:Port")
-    assert cells == ["121.44.111.12:45900", "61.177.173.18:29922", "61.177.173.18:55557", "61.177.173.18:35779"]
-
-
-def test_format_ipv4():
-    # todo: a future version should move the node IP into the file name, so 1:1, node:file.
-    assert format_ipv4("1.1.1.1") == "  1.  1.  1.  1"
-    assert format_ipv4("  1.  1.  1.  1") == "  1.  1.  1.  1"
-    assert format_ipv4("111.111.111.111") == "111.111.111.111"
-
-
-@pytest.mark.parametrize("plural_args, expected_suffix", [
-    ((4,), "s"),
-    ((1,), ""),
-    ((4, "eses",), "eses"),
-    ((1, "eses",), ""),
-    (([4], "eses",), ""),
-    (([1, 2, 34], "eses",), "eses"),
-])
-def test_plural(plural_args, expected_suffix):
-    assert plural(*plural_args) == expected_suffix
-
-
-@pytest.mark.parametrize("who_b_date, expected_human_date", [
-    ("Oct 30 06:10:57 2022", "Oct 30 06:10"),
-    ("Oct 30 06:10:57 2021", "Oct 30 2021"),
-    ("Oct 29 06:10:57 2022", "Oct 29 06:10"),
-    ("Oct 29 06:10:57 2021", "Oct 29 2021")
-])
-@patch("generalised_functions.datetime", autospec=True)
-def test_convert_last_reboot_date_to_human(mock_datetime, who_b_date, expected_human_date):
-    mock_datetime.utcnow = Mock(
-        return_value=datetime.datetime(2022, 1, 13, 13, 30, 00))
-    mock_datetime.strptime = datetime.datetime.strptime
-    assert convert_date_to_human_readable(who_b_date, "%b %d %H:%M:%S %Y") == expected_human_date
-
-
-@pytest.mark.parametrize("who_b_date, expected_human_date", [
-    ("2022-07-06 21:31", "Jul  6 21:31"),
-    ("2021-07-06 21:31", "Jul  6 2021"),
-    ("2022-07-26 21:31", "Jul 26 21:31"),
-    ("2021-07-26 21:31", "Jul 26 2021")
-])
-@patch("generalised_functions.datetime", autospec=True)
-def test_convert_who_b_date_to_human(mock_datetime, who_b_date, expected_human_date):
-    mock_datetime.utcnow = Mock(
-        return_value=datetime.datetime(2022, 1, 13, 13, 30, 00))
-    mock_datetime.strptime = datetime.datetime.strptime
-    assert convert_date_to_human_readable(who_b_date, "%Y-%m-%d %H:%M") == expected_human_date
-
-
-@patch("generalised_functions.smtplib.SMTP", autospec=True)
-def test_send_email(patched_smtp):
-    msg = EmailMessage()
-    badaddy = "superbadaddy"
-    badpass = "guessed"
-    send_email(msg, badaddy, badpass)
-    assert msg["From"] == badaddy
-    patched_smtp.assert_called_once_with("smtp." + badaddy, 587)
-    mock_smtp = patched_smtp.return_value
-    mock_smtp.ehlo.assert_has_calls([call(), call()])
-    mock_smtp.starttls.assert_called_once()
-    mock_smtp.login.assert_called_once_with(badaddy, badpass)
-    mock_smtp.send_message.assert_called_once()
-
-
-@patch.object(EmailMessage, "set_content", autospec=True)
-@patch("generalised_functions.plural", autospec=True, return_value="eze")
-@patch("generalised_functions.tabulate_csv_as_html", autospec=True,
-       return_value="sentinel.content")
-def test_compose_email_unique_ips(
-        patched_tabulate_csv_as_html, patched_plural, patched_set_content):
-    results = ["sentinel.result1", "sentinel.result2", "sentinel.result3"]
-    check_results = [Mock(CheckResult, to_csv=(lambda y: lambda: y)(x)) for
-                     x in results]
-    msg = compose_email(check_results, "dear@sir.com", "ipv4", "ewok", "")
-    assert msg["To"] == "dear@sir.com"
-    assert msg["Subject"] == "3 ewok statuseze"
-    patched_set_content.assert_called_once()
-    # autospec=True causes the "self" object (msg) to capture here:
-    patched_set_content.assert_called_once_with(
-        msg, "sentinel.content\n<hr/>\nsentinel.content\n<hr/>\nsentinel.content", subtype="html")
-    patched_plural.assert_called_once_with(check_results, "es")
-    patched_tabulate_csv_as_html.assert_has_calls([
-        call("ipv4", [check_results[0]]),
-        call("ipv4", [check_results[1]]),
-        call("ipv4", [check_results[2]])], any_order=False)
-
-
-@patch("generalised_functions.EmailMessage.set_content",
-       spec=EmailMessage.set_content)
-@patch("generalised_functions.plural", return_value="eze")
-@patch("generalised_functions.tabulate_csv_as_html",
-       return_value="sentinel.content")
-def test_compose_email(patched_tabulate_csv_as_html, patched_plural,
-                       patched_email_set_content):
-    check_results = [Mock(CheckResult, to_csv=(lambda y: lambda: y)(x))
-                     for x in
-                     [
-                         "1,metric1.1",
-                         "1,metric1.2",
-                         "1,metric1.3",
-                         "2,metric1.1"
-                     ]]
-    msg = compose_email(
-        check_results, "dear@sir.com", "ipv4,metric1", "ewok", "")
-    assert msg["To"] == "dear@sir.com"
-    assert msg["Subject"] == "4 ewok statuseze"
-    patched_email_set_content.assert_called_once_with(
-        "sentinel.content\n<hr/>\nsentinel.content", subtype='html')
-    patched_plural.assert_called_once_with(check_results, "es")
-    patched_tabulate_csv_as_html.assert_has_calls([
-        call("ipv4,metric1",
-             [check_results[0], check_results[1], check_results[2]]),
-        call("ipv4,metric1", [check_results[3]])])
-
-
-def test_parse_args_for_monitoring_help():
-    with pytest.raises(SystemExit):
-        parse_args_for_monitoring(["-h"], "sentinel.monitored")
-
-
-@pytest.mark.parametrize("extra_args, extra_expected_ns", [
-    ([], {}),
-    (["-esentinel.recipient_email_addy"], {"email_to": "sentinel.recipient_email_addy"}),
-    (["-nsentinel.nodes_file"], {"nodes_file": "sentinel.nodes_file"}),
-])
-def test_parse_args_for_monitoring(extra_args, extra_expected_ns):
-    MOCK_ARGS_LIST = ["sentinel.email_addy", "sentinel.email_password"]
-    MOCK_UNIT_NAME = "sentinel.monitored"
-    EXPECTED_MOCK_ARGS_OUT = dict(
-        email_addy="sentinel.email_addy",
-        email_to=None,
-        nodes_file="monitored_sentinel.monitoreds.json",
-        password="sentinel.email_password",
-        send_on_success=False
-    )
-    args = parse_args_for_monitoring(MOCK_ARGS_LIST + extra_args, MOCK_UNIT_NAME)
-    assert args == argparse.Namespace(**{**EXPECTED_MOCK_ARGS_OUT, **extra_expected_ns})
-
-
-@patch("generalised_functions.datetime", autospec=True)
-@patch("generalised_functions.load_results", autospec=True)
-@patch("generalised_functions.compose_email", autospec=True)
-@patch("generalised_functions.send_email", autospec=True)
-def test_email_wout_further_checks(mock_send_email, mock_compose_email, mock_load_results, mock_datetime):
-    mock_datetime.utcnow.return_value = datetime.datetime(2000, 1, 13, 13, 30, 00)
-    email_month_to = "feedmenow@datahog"
-    mock_check_result = Mock(CheckResult)
-    email_wout_further_checks(email_month_to, sentinel.sender, sentinel.password, mock_check_result)
-    mock_send_email.assert_called_once_with(
-        mock_compose_email.return_value, sentinel.sender, sentinel.password)
-    mock_load_results.assert_called_once_with(
-        "0001", mock_check_result.result_from_csv, mock_check_result.get_unit_name())
-    mock_compose_email.assert_called_once_with(
-        mock_load_results.return_value, "feedmenow@datahog", mock_check_result.get_header(),
-        mock_check_result.get_unit_name(), " for 0001")
-
-
-def test_load_results():
-    with patch("builtins.open", mock_open(read_data="ta\nyay\naye\nnay\n")) as mocked_open:
-        yymm = "4499"
-        results = load_results(yymm, lambda x: x, sentinel.unit)
-        print(results)
-        mocked_open.assert_called_once_with("{}/{}_{}.csv".format(RESULTS_DIR, sentinel.unit, yymm), "r")
-        assert results == ["ta\n", "yay\n", "aye\n", "nay\n"]
-
-
-def test_error_handler():
-    error_handler = ErrorHandler()
-    assert error_handler.msg["To"] == _MONITOR_EMAIL
-
-
-def test_error_handler_append():
-    prerolled_err = RuntimeError("testing")
-    error_handler = get_minimal_error_handler([prerolled_err])
-    assert error_handler.first_error == prerolled_err
-    assert error_handler.errors["here"] == [prerolled_err]
-
-
-def get_minimal_error_handler(errors_to_add: List[Exception]):
-    """Convenience method for getting an error handler which contains something to write about."""
-    error_handler = ErrorHandler()
-    error_handler.current_ip = "here"
-    for err in errors_to_add:
-        error_handler.append(err)
-    return error_handler
-
-
-def test_error_handler_set_subject_no_errors():
-    error_handler = ErrorHandler()
-    error_handler.set_subject(sentinel.unit_name)
-    assert error_handler.msg["Subject"] == "0 errors on 0 (failing) sentinel.unit_names, first at None: None"
-
-
-def test_error_handler_set_subject_1_error():
-    error_handler = ErrorHandler()
-    error_handler.current_ip = "here"
-    prerolled_err = RuntimeError("testing")
-    error_handler.append(prerolled_err)
-    error_handler.set_subject(sentinel.unit_name)
-    assert error_handler.msg["Subject"] == "1 error on 1 (failing) sentinel.unit_name, first at here: testing"
-
-
-@patch("generalised_functions.send_email")
-def test_error_handler_email_traces(mock_send_email):
-    prerolled_err = RuntimeError("testing")
-    error_handler = get_minimal_error_handler([prerolled_err])
-    addy, password = "bob@blueyonder", "password"
-    error_handler.email_traces(addy, password, sentinel.unit_name)
-    mock_send_email.assert_called_once_with(error_handler.msg, addy, password)
-    # No traceback, managing line numbers would be tricky:
-    assert error_handler.msg.get_payload() ==\
-           "================\nhere\nRuntimeError: testing\n\n\n================\n\n"
-
-
-def test_result_holder():
-    t1 = datetime.datetime.utcnow()
-    result_holder = ResultHolder()
-    t2 = datetime.datetime.utcnow()
-    assert t1 <= result_holder.time <= t2
-
-
-def test_result_holder_appends():
-    result_holder = ResultHolder()
-    check_result = Mock(CheckResult)
-    result_holder.append(check_result)
-    assert result_holder.results == [check_result]
-
-
-def test_result_holder_saves():
-    result_holder = ResultHolder()
-    greet_sequence = ["hi", "hello", "good day", "evening"]
-    # A second lambda wraps the original to capture the loop iterator which is lazily evaluated (captured when used).
-    check_results = [Mock(CheckResult, to_csv=(lambda y: lambda: y)(x)) for x in greet_sequence]
-    for result in check_results:
-        result_holder.append(result)
-    with patch("builtins.open", mock_open()) as mocked_open:
-        result_holder.save(sentinel.unit_name)
-        mocked_open.assert_called_once_with(
-            "{}/sentinel.unit_name_{}.csv".format(RESULTS_DIR, result_holder.time.strftime(DATE_MON_FMT)), "a+")
-        mocked_open.return_value.write.assert_has_calls([call(x) for x in greet_sequence])
+from generalised_functions import CheckResult, \
+    process_args, \
+    iterate_rmt_servers
+from indie_gen_funcs import ErrorHandler, _MONITOR_EMAIL
 
 
 @patch("generalised_functions.parse_args_for_monitoring", autospec=True, return_value=type('', (), {
@@ -283,20 +14,21 @@ def test_result_holder_saves():
     "send_on_success": False
 })())
 @patch("generalised_functions.CheckResult", autospec=True)
-@patch("generalised_functions.IInterrogator", autospec=True)
+@patch("generalised_functions.interrog_routine", autospec=True)
 @patch("generalised_functions.ResultHolder", autospec=True)
 @patch("generalised_functions.iterate_rmt_servers", autospec=True,
        return_value=create_autospec(ErrorHandler()))
 def test_process_args(
-        mock_iterate_rmt_servers, mock_result_holder, mock_interrog, mock_c_res, mock_parse_args):
-    process_args(sentinel.args_list, mock_c_res, mock_interrog)
+        mock_iterate_rmt_servers, mock_result_holder,
+        mock_interrog_routine, mock_c_res, mock_parse_args):
+    process_args(sentinel.args_list, mock_c_res)
     mock_parse_args.assert_called_once_with(
         sentinel.args_list, mock_c_res.get_unit_name.return_value)
     mock_result_holder.assert_called_once_with()
     mock_iterate_rmt_servers.assert_called_once_with(
         sentinel.nodes_file,
         mock_c_res,
-        mock_interrog,
+        mock_interrog_routine,
         mock_result_holder.return_value)
 
 
@@ -310,23 +42,24 @@ def test_process_args(
 @patch("generalised_functions.send_email", autospec=True)
 @patch("generalised_functions.compose_email", return_value=sentinel.msg)
 @patch("generalised_functions.CheckResult", autospec=True)
-@patch("generalised_functions.IInterrogator", autospec=True)
 @patch("generalised_functions.ResultHolder", autospec=True)
+@patch("generalised_functions.interrog_routine", autospec=True)
 @patch("generalised_functions.iterate_rmt_servers", autospec=True,
        return_value=create_autospec(ErrorHandler()))
 def test_process_args_then_send(
-        mock_iterate_rmt_servers, mock_result_holder, mock_interrog,
-        mock_c_res, mock_compose_email, mock_send_email, mock_parse_args):
+        mock_iterate_rmt_servers, mock_interrog_routine,
+        mock_result_holder, mock_c_res, mock_compose_email,
+        mock_send_email, mock_parse_args):
     mock_c_res.get_unit_name.return_value = sentinel.unit
     mock_c_res.get_header.return_value = sentinel.header
     mock_result_holder.return_value.results = sentinel.results
-    process_args(sentinel.args_list, mock_c_res, mock_interrog)
+    process_args(sentinel.args_list, mock_c_res)
     mock_parse_args.assert_called_once_with(sentinel.args_list, sentinel.unit)
     mock_result_holder.assert_called_once_with()
     mock_iterate_rmt_servers.assert_called_once_with(
         sentinel.nodes_file,
         mock_c_res,
-        mock_interrog,
+        mock_interrog_routine,
         mock_result_holder.return_value)
     mock_compose_email.assert_called_once_with(
         sentinel.results, _MONITOR_EMAIL, sentinel.header, sentinel.unit, "")
@@ -343,35 +76,22 @@ def test_process_args_then_send(
 })())
 @patch("generalised_functions.CheckResult", spec=CheckResult)
 @patch("generalised_functions.email_wout_further_checks", autospec=True)
-@patch("generalised_functions.IInterrogator", autospec=True)
 @patch("generalised_functions.ResultHolder", autospec=True)
+@patch("generalised_functions.interrog_routine", autospec=True)
 @patch("generalised_functions.iterate_rmt_servers", autospec=True,
        return_value=create_autospec(ErrorHandler()))
 def test_process_args_and_email(
-        mock_iterate_rmt_servers, mock_result_holder, mock_interrog,
-        mock_email_wout_further_checks, mock_c_res, mock_parse_args):
+        mock_iterate_rmt_servers, mock_interrog_routine,
+        mock_result_holder, mock_email_wout_further_checks,
+        mock_c_res, mock_parse_args):
     mock_c_res.get_unit_name.return_value = sentinel.unit
-    process_args(sentinel.args_list, mock_c_res, sentinel.iinterrogator)
+    process_args(sentinel.args_list, mock_c_res)
     mock_parse_args.assert_called_once_with(sentinel.args_list, sentinel.unit)
     mock_result_holder.assert_not_called()
     mock_iterate_rmt_servers.assert_not_called()
-    mock_interrog.assert_not_called()
+    mock_interrog_routine.assert_not_called()
     mock_email_wout_further_checks.assert_called_once_with(
         sentinel.email_to, sentinel.email_addy, sentinel.password, mock_c_res)
-
-
-@patch("generalised_functions.get_public_ip", autospec=True,
-       return_value=sentinel.pub_ip)
-def test_monitor_runners_ipv4(mocked_get_public_ip):
-    with patch("builtins.open",
-               mock_open(read_data="8.8.8.8\n")) as mocked_open:
-        monitor_runners_ipv4()
-        mocked_open.assert_has_calls([
-            call(f"{RESULTS_DIR}/public_ip_history.txt"),
-            call(f"{RESULTS_DIR}/public_ip_history.txt", "a+")
-        ], any_order=True)
-        mocked_open.return_value.write.assert_called_once_with(sentinel.pub_ip)
-    mocked_get_public_ip.assert_called_once_with()
 
 
 @patch("generalised_functions.monitor_runners_ipv4", autospec=True)
@@ -403,21 +123,6 @@ def test_iterate_rmt_servers_good_pings(
     mocked_open.assert_called_once_with(sentinel.file_name, encoding="utf8")
     mock_ipv4_monitor.assert_called_once_with()
 
-
-@patch("generalised_functions.requests.get", autospec=True)
-def test_get_public_ip(mock_requests_get):
-    test_ip = "8.8.8.8"
-    mock_requests_get.return_value.json.return_value = {
-        "ip": test_ip,
-        "hostname": "9f271a71.btinternet.com",
-        "city": "Birmingham",
-        "loc": "52.4778,-1.8990",
-        "org": "AS2856 British Telecommunications PLC",
-        "postal": "B2",
-        "readme": "https://ipinfo.io/missingauth"
-    }
-    pub_ip = get_public_ip()
-    assert pub_ip == test_ip
 
 
 #todo on a fresh install "results" isn't a directory and looking for public ip history there would break it.

--- a/tests/test_indie_gen_funcs.py
+++ b/tests/test_indie_gen_funcs.py
@@ -1,0 +1,324 @@
+import argparse
+import datetime
+from email.message import EmailMessage
+from typing import List
+from unittest.mock import Mock, patch, call, sentinel, mock_open, create_autospec
+
+import pytest
+
+from check_result import format_ipv4
+from generalised_functions import send_email, monitor_runners_ipv4, \
+    compose_email, parse_args_for_monitoring, CheckResult, \
+    email_wout_further_checks, \
+    ResultHolder, process_args, \
+    iterate_rmt_servers
+from indie_gen_funcs import ErrorHandler, find_cells_under, \
+    convert_date_to_human_readable, load_results, RESULTS_DIR, get_public_ip, plural
+import indie_gen_funcs
+
+
+def test_easy_find_cells_under(ss_lines_1):
+    # Here we have cells both inside and outside of the column headers.
+    cells = find_cells_under(ss_lines_1, "Local Address:Port")
+    assert cells == ["42.8.101.220:22", "42.8.101.220:22", "42.8.101.220:22"]
+    cells = find_cells_under(ss_lines_1, "Peer Address:Port")
+    assert cells == ["121.44.111.12:45900", "61.177.173.18:51931", "222.186.30.112:61668"]
+
+
+def test_harder_find_cells_under(ss_lines_2):
+    # Here we have the more extreme case where the columns are cramped (as far as they go without wrapping).
+    # This causes problems because taking a delimiter of 1 space splits some column headers.
+    # I would like to unlimit the pty width in paramiko.
+    cells = find_cells_under(ss_lines_2, "Local Address:Port")
+    assert cells == ["42.8.101.220:22", "42.8.101.220:22", "42.8.101.220:22", "42.8.101.220:22"]
+    cells = find_cells_under(ss_lines_2, "Peer Address:Port")
+    assert cells == ["121.44.111.12:45900", "61.177.173.18:29922", "61.177.173.18:55557", "61.177.173.18:35779"]
+
+
+def test_format_ipv4():
+    # todo: a future version should move the node IP into the file name, so 1:1, node:file.
+    assert format_ipv4("1.1.1.1") == "  1.  1.  1.  1"
+    assert format_ipv4("  1.  1.  1.  1") == "  1.  1.  1.  1"
+    assert format_ipv4("111.111.111.111") == "111.111.111.111"
+
+
+@pytest.mark.parametrize("plural_args, expected_suffix", [
+    ((4,), "s"),
+    ((1,), ""),
+    ((4, "eses",), "eses"),
+    ((1, "eses",), ""),
+    (([4], "eses",), ""),
+    (([1, 2, 34], "eses",), "eses"),
+])
+def test_plural(plural_args, expected_suffix):
+    assert plural(*plural_args) == expected_suffix
+
+
+@pytest.mark.parametrize("who_b_date, expected_human_date", [
+    ("Oct 30 06:10:57 2022", "Oct 30 06:10"),
+    ("Oct 30 06:10:57 2021", "Oct 30 2021"),
+    ("Oct 29 06:10:57 2022", "Oct 29 06:10"),
+    ("Oct 29 06:10:57 2021", "Oct 29 2021")
+])
+@patch("indie_gen_funcs.datetime", autospec=True)
+def test_convert_last_reboot_date_to_human(mock_datetime, who_b_date, expected_human_date):
+    mock_datetime.utcnow = Mock(
+        return_value=datetime.datetime(2022, 1, 13, 13, 30, 00))
+    mock_datetime.strptime = datetime.datetime.strptime
+    assert convert_date_to_human_readable(who_b_date, "%b %d %H:%M:%S %Y") == expected_human_date
+
+
+@pytest.mark.parametrize("who_b_date, expected_human_date", [
+    ("2022-07-06 21:31", "Jul  6 21:31"),
+    ("2021-07-06 21:31", "Jul  6 2021"),
+    ("2022-07-26 21:31", "Jul 26 21:31"),
+    ("2021-07-26 21:31", "Jul 26 2021")
+])
+@patch("indie_gen_funcs.datetime", autospec=True)
+def test_convert_who_b_date_to_human(mock_datetime, who_b_date, expected_human_date):
+    mock_datetime.utcnow = Mock(
+        return_value=datetime.datetime(2022, 1, 13, 13, 30, 00))
+    mock_datetime.strptime = datetime.datetime.strptime
+    assert convert_date_to_human_readable(who_b_date, "%Y-%m-%d %H:%M") == expected_human_date
+
+
+@patch("indie_gen_funcs.smtplib.SMTP", autospec=True)
+def test_send_email(patched_smtp):
+    msg = EmailMessage()
+    badaddy = "superbadaddy"
+    badpass = "guessed"
+    send_email(msg, badaddy, badpass)
+    assert msg["From"] == badaddy
+    patched_smtp.assert_called_once_with("smtp." + badaddy, 587)
+    mock_smtp = patched_smtp.return_value
+    mock_smtp.ehlo.assert_has_calls([call(), call()])
+    mock_smtp.starttls.assert_called_once()
+    mock_smtp.login.assert_called_once_with(badaddy, badpass)
+    mock_smtp.send_message.assert_called_once()
+
+
+@patch.object(EmailMessage, "set_content", autospec=True)
+@patch("indie_gen_funcs.plural", autospec=True, return_value="eze")
+@patch("indie_gen_funcs.tabulate_csv_as_html", autospec=True,
+       return_value="sentinel.content")
+def test_compose_email_unique_ips(
+        patched_tabulate_csv_as_html, patched_plural, patched_set_content):
+    results = ["sentinel.result1", "sentinel.result2", "sentinel.result3"]
+    check_results = [Mock(CheckResult, to_csv=(lambda y: lambda: y)(x)) for
+                     x in results]
+    msg = compose_email(check_results, "dear@sir.com", "ipv4", "ewok", "")
+    assert msg["To"] == "dear@sir.com"
+    assert msg["Subject"] == "3 ewok statuseze"
+    patched_set_content.assert_called_once()
+    # autospec=True causes the "self" object (msg) to capture here:
+    patched_set_content.assert_called_once_with(
+        msg, "sentinel.content\n<hr/>\nsentinel.content\n<hr/>\nsentinel.content", subtype="html")
+    patched_plural.assert_called_once_with(check_results, "es")
+    patched_tabulate_csv_as_html.assert_has_calls([
+        call("ipv4", [check_results[0]]),
+        call("ipv4", [check_results[1]]),
+        call("ipv4", [check_results[2]])], any_order=False)
+
+
+@patch("indie_gen_funcs.EmailMessage.set_content",
+       spec=EmailMessage.set_content)
+@patch("indie_gen_funcs.plural", return_value="eze")
+@patch("indie_gen_funcs.tabulate_csv_as_html",
+       return_value="sentinel.content")
+def test_compose_email(patched_tabulate_csv_as_html, patched_plural,
+                       patched_email_set_content):
+    check_results = [Mock(CheckResult, to_csv=(lambda y: lambda: y)(x))
+                     for x in
+                     [
+                         "1,metric1.1",
+                         "1,metric1.2",
+                         "1,metric1.3",
+                         "2,metric1.1"
+                     ]]
+    msg = compose_email(
+        check_results, "dear@sir.com", "ipv4,metric1", "ewok", "")
+    assert msg["To"] == "dear@sir.com"
+    assert msg["Subject"] == "4 ewok statuseze"
+    patched_email_set_content.assert_called_once_with(
+        "sentinel.content\n<hr/>\nsentinel.content", subtype='html')
+    patched_plural.assert_called_once_with(check_results, "es")
+    patched_tabulate_csv_as_html.assert_has_calls([
+        call("ipv4,metric1",
+             [check_results[0], check_results[1], check_results[2]]),
+        call("ipv4,metric1", [check_results[3]])])
+
+
+def test_parse_args_for_monitoring_help():
+    with pytest.raises(SystemExit):
+        parse_args_for_monitoring(["-h"], "sentinel.monitored")
+
+
+@pytest.mark.parametrize("extra_args, extra_expected_ns", [
+    ([], {}),
+    (["-esentinel.recipient_email_addy"], {"email_to": "sentinel.recipient_email_addy"}),
+    (["-nsentinel.nodes_file"], {"nodes_file": "sentinel.nodes_file"}),
+])
+def test_parse_args_for_monitoring(extra_args, extra_expected_ns):
+    MOCK_ARGS_LIST = ["sentinel.email_addy", "sentinel.email_password"]
+    MOCK_UNIT_NAME = "sentinel.monitored"
+    EXPECTED_MOCK_ARGS_OUT = dict(
+        email_addy="sentinel.email_addy",
+        email_to=None,
+        nodes_file="monitored_sentinel.monitoreds.json",
+        password="sentinel.email_password",
+        send_on_success=False
+    )
+    args = parse_args_for_monitoring(MOCK_ARGS_LIST + extra_args, MOCK_UNIT_NAME)
+    assert args == argparse.Namespace(**{**EXPECTED_MOCK_ARGS_OUT, **extra_expected_ns})
+
+
+@patch("indie_gen_funcs.datetime", autospec=True)
+@patch("indie_gen_funcs.load_results", autospec=True)
+@patch("indie_gen_funcs.compose_email", autospec=True)
+@patch("indie_gen_funcs.send_email", autospec=True)
+def test_email_wout_further_checks(mock_send_email, mock_compose_email, mock_load_results, mock_datetime):
+    mock_datetime.utcnow.return_value = datetime.datetime(2000, 1, 13, 13, 30, 00)
+    email_month_to = "feedmenow@datahog"
+    mock_check_result = Mock(CheckResult)
+    email_wout_further_checks(email_month_to, sentinel.sender, sentinel.password, mock_check_result)
+    mock_send_email.assert_called_once_with(
+        mock_compose_email.return_value, sentinel.sender, sentinel.password)
+    mock_load_results.assert_called_once_with(
+        "0001", mock_check_result.result_from_csv, mock_check_result.get_unit_name())
+    mock_compose_email.assert_called_once_with(
+        mock_load_results.return_value, "feedmenow@datahog", mock_check_result.get_header(),
+        mock_check_result.get_unit_name(), " for 0001")
+
+
+def test_load_results():
+    with patch("builtins.open", mock_open(read_data="ta\nyay\naye\nnay\n")) as mocked_open:
+        yymm = "4499"
+        results = load_results(yymm, lambda x: x, sentinel.unit)
+        print(results)
+        mocked_open.assert_called_once_with("{}/{}_{}.csv".format(RESULTS_DIR, sentinel.unit, yymm), "r")
+        assert results == ["ta\n", "yay\n", "aye\n", "nay\n"]
+
+
+def test_error_handler():
+    error_handler = ErrorHandler()
+    assert error_handler.msg["To"] == indie_gen_funcs._MONITOR_EMAIL
+
+
+def test_error_handler_append():
+    prerolled_err = RuntimeError("testing")
+    error_handler = get_minimal_error_handler([prerolled_err])
+    assert error_handler.first_error == prerolled_err
+    assert error_handler.errors["here"] == [prerolled_err]
+
+
+def get_minimal_error_handler(errors_to_add: List[Exception]):
+    """Convenience method for getting an error handler which contains something to write about."""
+    error_handler = ErrorHandler()
+    error_handler.current_ip = "here"
+    for err in errors_to_add:
+        error_handler.append(err)
+    return error_handler
+
+
+def test_error_handler_set_subject_no_errors():
+    error_handler = ErrorHandler()
+    error_handler.set_subject(sentinel.unit_name)
+    assert error_handler.msg["Subject"] == "0 errors on 0 (failing) sentinel.unit_names, first at None: None"
+
+
+def test_error_handler_set_subject_1_error():
+    error_handler = ErrorHandler()
+    error_handler.current_ip = "here"
+    prerolled_err = RuntimeError("testing")
+    error_handler.append(prerolled_err)
+    error_handler.set_subject(sentinel.unit_name)
+    assert error_handler.msg["Subject"] == "1 error on 1 (failing) sentinel.unit_name, first at here: testing"
+
+
+@patch("indie_gen_funcs.send_email")
+def test_error_handler_email_traces(mock_send_email):
+    prerolled_err = RuntimeError("testing")
+    error_handler = get_minimal_error_handler([prerolled_err])
+    addy, password = "bob@blueyonder", "password"
+    error_handler.email_traces(addy, password, sentinel.unit_name)
+    mock_send_email.assert_called_once_with(error_handler.msg, addy, password)
+    # No traceback, managing line numbers would be tricky:
+    assert error_handler.msg.get_payload() ==\
+           "================\nhere\nRuntimeError: testing\n\n\n================\n\n"
+
+
+def test_result_holder():
+    t1 = datetime.datetime.utcnow()
+    result_holder = ResultHolder()
+    t2 = datetime.datetime.utcnow()
+    assert t1 <= result_holder.time <= t2
+
+
+def test_result_holder_appends():
+    result_holder = ResultHolder()
+    check_result = Mock(CheckResult)
+    result_holder.append(check_result)
+    assert result_holder.results == [check_result]
+
+
+def test_result_holder_saves():
+    result_holder = ResultHolder()
+    greet_sequence = ["hi", "hello", "good day", "evening"]
+    # A second lambda wraps the original to capture the loop iterator which is lazily evaluated (captured when used).
+    check_results = [Mock(CheckResult, to_csv=(lambda y: lambda: y)(x)) for x in greet_sequence]
+    for result in check_results:
+        result_holder.append(result)
+    with patch("builtins.open", mock_open()) as mocked_open:
+        result_holder.save(sentinel.unit_name)
+        mocked_open.assert_called_once_with(
+            "{}/sentinel.unit_name_{}.csv".format(
+                RESULTS_DIR, result_holder.time.strftime(
+                    indie_gen_funcs.DATE_MON_FMT)), "a+")
+        mocked_open.return_value.write.assert_has_calls([call(x) for x in greet_sequence])
+
+
+@patch("indie_gen_funcs.get_public_ip", autospec=True,
+       return_value=sentinel.pub_ip)
+def test_monitor_runners_ipv4(mocked_get_public_ip):
+    with patch("builtins.open",
+               mock_open(read_data="8.8.8.8\n")) as mocked_open:
+        monitor_runners_ipv4()
+        mocked_open.assert_has_calls([
+            call(f"{RESULTS_DIR}/public_ip_history.txt"),
+            call(f"{RESULTS_DIR}/public_ip_history.txt", "a+")
+        ], any_order=True)
+        mocked_open.return_value.write.assert_called_once_with(sentinel.pub_ip)
+    mocked_get_public_ip.assert_called_once_with()
+
+
+@patch("indie_gen_funcs.requests.get", autospec=True)
+def test_get_public_ip(mock_requests_get):
+    test_ip = "8.8.8.8"
+    mock_requests_get.return_value.json.return_value = {
+        "ip": test_ip,
+        "hostname": "9f271a71.btinternet.com",
+        "city": "Birmingham",
+        "loc": "52.4778,-1.8990",
+        "org": "AS2856 British Telecommunications PLC",
+        "postal": "B2",
+        "readme": "https://ipinfo.io/missingauth"
+    }
+    pub_ip = get_public_ip()
+    assert pub_ip == test_ip
+
+
+#todo on a fresh install "results" isn't a directory and looking for public ip history there would break it.
+
+'''
+python3[8103]:   File "/home/leon/server_monitor/generalised_functions.py", line 354, in process_args
+python3[8103]:     err_handler = iterate_rmt_servers(args.nodes_file, check_result,
+python3[8103]:   File "/home/leon/server_monitor/generalised_functions.py", line 391, in iterate_rmt_servers
+python3[8103]:     monitor_runners_ipv4()
+python3[8103]:   File "/home/leon/server_monitor/generalised_functions.py", line 70, in monitor_runners_ipv4
+python3[8103]:     with open(f"{RESULTS_DIR}/public_ip_history.txt", "a+") as f:
+python3[8103]: FileNotFoundError: [Errno 2] No such file or directory: 'results/public_ip_history.txt'
+systemd[1]: rmt-monitor.service: Main process exited, code=exited, status=1/FAILURE
+systemd[1]: rmt-monitor.service: Failed with result 'exit-code'.
+systemd[1]: rmt-monitor.service: Consumed 1.799s CPU time.
+'''
+

--- a/tests/test_interrog.py
+++ b/tests/test_interrog.py
@@ -1,0 +1,104 @@
+import datetime
+from unittest.mock import patch, sentinel, Mock
+
+import requests
+from requests.exceptions import SSLError
+
+from indie_gen_funcs import DAY_TIME_FMT, ResultHolder, ErrorHandler
+from interrog_routines import interrog_routine
+
+
+def configure_mock_get(mock_get, mock_http_response_time):
+    mock_get.return_value.elapsed.total_seconds.return_value = mock_http_response_time
+    mock_get.return_value.ok = True
+    mock_get.return_value.status_code = 200
+
+
+def get_interrog_mock_args():
+    result_holder = Mock(ResultHolder, time=datetime.datetime.utcnow())
+    err_handler = Mock(ErrorHandler)
+    return err_handler, result_holder
+
+
+def get_ave_max_latencies(latencies):
+    latencies = list(map(float, latencies))
+    ave_latency = str(int(round(sum(latencies) / len(latencies))))
+    max_latency = str(int(round(max(latencies))))
+    return ave_latency, max_latency
+
+
+
+
+@patch("interrog_routines.CheckResult", autospec=True)
+@patch.object(requests, "get", autospec=True)
+@patch("interrog_routines.SSHInterrogator.do_queries", autospec=True)
+def test_interrog_routine(mock_queries, mock_get, mock_check_result):
+    mock_http_response_time = 0.0421
+    sample_latencies = ['16.0', '15.0', '18.0', '16.0']
+    configure_mock_get(mock_get, mock_http_response_time)
+    err_handler, result_holder = get_interrog_mock_args()
+    ave_latency, max_latency = get_ave_max_latencies(sample_latencies)
+    interrog_routine(
+        err_handler,
+        {"home_page": sentinel.home_page},
+        result_holder, sentinel.ipv4, sample_latencies)
+    mock_check_result.assert_called_once_with(
+        result_holder.time.strftime(DAY_TIME_FMT), sentinel.ipv4,
+        ave_latency, max_latency,
+        str(int(round(1000 * mock_http_response_time))),
+        str(mock_get.return_value.status_code), None, None,
+        None, None, None, None)
+    mock_queries.assert_called_once()
+    mock_get.assert_called_once_with(sentinel.home_page, timeout=5, verify=True)
+
+
+@patch("interrog_routines.CheckResult", autospec=True)
+@patch.object(requests, "get", autospec=True)
+@patch("interrog_routines.SSHInterrogator.do_queries", autospec=True)
+def test_self_sign_interrog_routine(mock_queries, mock_get, mock_check_result):
+    mock_http_response_time = 0.0421
+    sample_latencies = ['16.0', '15.0', '18.0', '16.0']
+    configure_mock_get(mock_get, mock_http_response_time)
+    err_handler, result_holder = get_interrog_mock_args()
+    interrog_routine(
+        err_handler,
+        {"home_page": sentinel.home_page, "verify": sentinel.vrfy_path},
+        result_holder, sentinel.ipv4, sample_latencies)
+    mock_check_result.assert_called_once()
+    mock_queries.assert_called_once()
+    mock_get.assert_called_once_with(
+        sentinel.home_page, timeout=5, verify=sentinel.vrfy_path)
+
+
+@patch("interrog_routines.CheckResult", autospec=True)
+@patch.object(requests, "get", autospec=True, side_effect=[
+    SSLError(), Mock(ok=True, status_code=200, elapsed=Mock(total_seconds=lambda:200))])
+@patch("interrog_routines.SSHInterrogator.do_queries", autospec=True)
+def test_interrog_routine_when_cert_expired(mock_queries, mock_get, mock_check_result):
+    sample_latencies = ['16.0', '15.0', '18.0', '16.0']
+    # configure_mock_get(mock_get, mock_http_response_time)
+    err_handler, result_holder = get_interrog_mock_args()
+    interrog_routine(
+        err_handler,
+        {"home_page": sentinel.home_page},
+        result_holder, sentinel.ipv4, sample_latencies)
+    mock_check_result.assert_called_once()
+    assert mock_get.call_count == 2
+    mock_queries.assert_called_once()
+    err_handler.append.assert_called_once()
+
+
+@patch("interrog_routines.CheckResult", autospec=True)
+@patch.object(requests, "get", autospec=True, side_effect=requests.exceptions.ConnectionError())
+@patch("interrog_routines.SSHInterrogator.do_queries", autospec=True)
+def test_interrog_routine_when_server_unresponsive(mock_queries, mock_get, mock_check_result):
+    sample_latencies = ['16.0', '15.0', '18.0', '16.0']
+    err_handler, result_holder = get_interrog_mock_args()
+    interrog_routine(
+        err_handler,
+        {"home_page": sentinel.home_page},
+        result_holder, sentinel.ipv4, sample_latencies)
+    mock_check_result.assert_not_called()
+    mock_get.assert_called_once()
+    mock_queries.assert_not_called()
+    err_handler.append.assert_called_once_with(mock_get.side_effect)

--- a/tests/test_paramiko_client.py
+++ b/tests/test_paramiko_client.py
@@ -7,13 +7,13 @@ from paramiko.client import SSHClient
 from paramiko.pkey import PKey
 from paramiko.ssh_exception import AuthenticationException, BadHostKeyException
 
-import generalised_functions
+import indie_gen_funcs
 from paramiko_client import SSHInterrogator, MinerInterrogator
 
 SENTINEL_ERROR = RuntimeError("test injected")
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_parse_user_csv(mock_error_handler):
     interrogator = SSHInterrogator(mock_error_handler)
     assert interrogator.parse_user_csv("forty,five") == {"forty", "five"}
@@ -38,7 +38,7 @@ def mk_interrogator(mock_error_handler, mock_lines, side_effect=None):
     return interrogator
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_ports_unknown(mock_error_handler, ss_lines_1):
     interrogator = mk_interrogator(mock_error_handler, ss_lines_1)
     interrogator.query_ports(set())
@@ -46,7 +46,7 @@ def test_query_ports_unknown(mock_error_handler, ss_lines_1):
     mock_error_handler.append.assert_not_called()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_ports_known(mock_error_handler, ss_lines_1):
     interrogator = mk_interrogator(mock_error_handler, ss_lines_1)
     interrogator.query_ports({"22"})
@@ -54,14 +54,14 @@ def test_query_ports_known(mock_error_handler, ss_lines_1):
     mock_error_handler.append.assert_not_called()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_ports_fail(mock_error_handler, ss_lines_1):
     interrogator = mk_interrogator(mock_error_handler, ss_lines_1, SENTINEL_ERROR)
     interrogator.query_ports({"22"})
     mock_error_handler.append.assert_called_once_with(SENTINEL_ERROR)
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 @patch("paramiko_client.SSHInterrogator.initialise_connection", return_value=None)
 @patch("paramiko_client.SSHInterrogator.remote_tentative_calls")
 def test_do_queries(mock_remote_tentative_calls, mock_initialise_connection, mock_error_handler, mock_rmt_pc_1):
@@ -71,7 +71,7 @@ def test_do_queries(mock_remote_tentative_calls, mock_initialise_connection, moc
     mock_remote_tentative_calls.assert_called_once_with(mock_rmt_pc_1)
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 @patch("paramiko_client.SSHInterrogator.initialise_connection", return_value=None)
 @patch("paramiko_client.SSHInterrogator.remote_tentative_calls", side_effect=SENTINEL_ERROR)
 def test_do_queries_throwing(mock_remote_tentative_calls, mock_initialise_connection, mock_error_handler, mock_rmt_pc_1):
@@ -82,7 +82,7 @@ def test_do_queries_throwing(mock_remote_tentative_calls, mock_initialise_connec
     mock_remote_tentative_calls.assert_called_once_with(mock_rmt_pc_1)
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 @patch("paramiko_client.SSHClient", autospec=True)
 @patch("paramiko_client.paramiko.AutoAddPolicy", autospec=True)
 def test_initialise_connection(mock_autoaddpolicy, mock_ssh_client, mock_error_handler, mock_rmt_pc_1):
@@ -98,7 +98,7 @@ def test_initialise_connection(mock_autoaddpolicy, mock_ssh_client, mock_error_h
     mock_ssh_client.assert_called_once_with()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 @patch("paramiko_client.SSHClient", autospec=True)
 @patch("paramiko_client.paramiko.AutoAddPolicy", autospec=True)
 def test_initialise_connection_alt_auth_method(mock_autoaddpolicy, mock_ssh_client, mock_error_handler, mock_rmt_pc_2):
@@ -122,7 +122,7 @@ def test_initialise_connection_alt_auth_method(mock_autoaddpolicy, mock_ssh_clie
     mock_ssh_client.assert_called_once_with()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 @patch("paramiko_client.SSHClient", autospec=True)
 @patch("paramiko_client.paramiko.AutoAddPolicy", autospec=True)
 def test_initialise_connection_auth_exception(
@@ -143,7 +143,7 @@ def test_initialise_connection_auth_exception(
     mock_ssh_client.assert_called_once_with()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 @patch("paramiko_client.SSHClient", autospec=True)
 @patch("paramiko_client.paramiko.AutoAddPolicy", autospec=True)
 def test_initialise_connection_bad_key_exception(
@@ -175,7 +175,7 @@ def test_initialise_connection_bad_key_exception(
     mock_ssh_client.assert_called_once_with()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_free(mock_error_handler, free_lines_1):
     interrogator = mk_interrogator(mock_error_handler, free_lines_1)
     interrogator.query_free()
@@ -185,14 +185,14 @@ def test_query_free(mock_error_handler, free_lines_1):
     mock_error_handler.append.assert_not_called()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_free_fail(mock_error_handler, free_lines_1):
     interrogator = mk_interrogator(mock_error_handler, free_lines_1, SENTINEL_ERROR)
     interrogator.query_free()
     mock_error_handler.append.assert_called_once_with(SENTINEL_ERROR)
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_ssh_peers(mock_error_handler, sport22_lines):
     interrogator = mk_interrogator(mock_error_handler, sport22_lines)
     interrogator.query_ssh_peers(set())
@@ -201,14 +201,14 @@ def test_query_ssh_peers(mock_error_handler, sport22_lines):
     mock_error_handler.append.assert_not_called()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_ssh_peers_fail(mock_error_handler, sport22_lines):
     interrogator = mk_interrogator(mock_error_handler, sport22_lines, SENTINEL_ERROR)
     interrogator.query_ssh_peers(set())
     mock_error_handler.append.assert_called_once_with(SENTINEL_ERROR)
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_boot_time(mock_error_handler):
     interrogator = mk_interrogator(mock_error_handler, ["         system boot  2021-10-01 08:55", ""])
     interrogator.query_boot_time()
@@ -217,14 +217,14 @@ def test_query_boot_time(mock_error_handler):
     mock_error_handler.append.assert_not_called()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_boot_time_fail(mock_error_handler):
     interrogator = mk_interrogator(mock_error_handler, ["         system boot  2021-10-01 08:55", ""], SENTINEL_ERROR)
     interrogator.query_boot_time()
     mock_error_handler.append.assert_called_once_with(SENTINEL_ERROR)
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_disk_free(mock_error_handler):
     interrogator = mk_interrogator(mock_error_handler, ["Avail", "124G"])
     interrogator.query_disk_free()
@@ -233,7 +233,7 @@ def test_query_disk_free(mock_error_handler):
     mock_error_handler.append.assert_not_called()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 def test_query_disk_free_fail(mock_error_handler):
     interrogator = mk_interrogator(mock_error_handler, ["Avail", "124G"], SENTINEL_ERROR)
     interrogator.query_disk_free()
@@ -256,7 +256,7 @@ def test_remote_tentative_calls():
         call(mock_rmt_pc.get("known_ports", "")),
     ])
     fake_instance.query_ssh_peers.assert_called_once_with(
-        {generalised_functions.PUBLIC_IP, "NOO.YOO.GET.LOS"})
+        {indie_gen_funcs.PUBLIC_IP, "NOO.YOO.GET.LOS"})
     fake_instance.query_ports.assert_called_once_with(
         SSHInterrogator.parse_user_csv(mock_rmt_pc["known_ports"]))
 
@@ -273,7 +273,7 @@ def test_read_gpu():
     assert gpu is None
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 @patch("paramiko_client.MinerInterrogator.read_gpu", autospec=True, side_effect=[0, 1, 2, None])
 def test_query_gpus(mock_read_gpu, mock_error_handler, nvidia_smi_lines_1):
     interrogator = MinerInterrogator(mock_error_handler)
@@ -289,7 +289,7 @@ def test_query_gpus(mock_read_gpu, mock_error_handler, nvidia_smi_lines_1):
          call('                                                                               \n')])
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 @patch("paramiko_client.SSHInterrogator.initialise_connection", return_value=None)
 @patch("paramiko_client.MinerInterrogator.query_gpus")
 @patch("paramiko_client.SSHInterrogator.remote_tentative_calls")
@@ -305,7 +305,7 @@ def test_miner_do_queries(
     mock_error_handler.append.assert_not_called()
 
 
-@patch("server_mon.ErrorHandler", autospec=True)
+@patch("paramiko_client.ErrorHandler", autospec=True)
 @patch("paramiko_client.SSHInterrogator.initialise_connection", side_effect=SENTINEL_ERROR)
 def test_miner_do_queries_fail(mock_initialise_connection, mock_error_handler, mock_rmt_pc_1):
     interrogator = MinerInterrogator(mock_error_handler)

--- a/tests/test_ping_functions.py
+++ b/tests/test_ping_functions.py
@@ -1,7 +1,7 @@
 import subprocess
 from unittest.mock import Mock, patch, sentinel
 
-from generalised_functions import ErrorHandler
+from indie_gen_funcs import ErrorHandler
 from ping_functions import ping, get_ping_latencies
 
 STDOUT_WINDOWS_ONLINE = \

--- a/tests/test_server_pinger.py
+++ b/tests/test_server_pinger.py
@@ -2,7 +2,7 @@ import datetime
 import subprocess
 from unittest.mock import patch, sentinel, Mock, mock_open, call
 
-from generalised_functions import RESULTS_DIR
+from indie_gen_funcs import RESULTS_DIR
 from server_pinger import time_pings, ping_all_day, PingResult, save_days_pings
 
 PING_OUTPUT = \


### PR DESCRIPTION
I don't know how exactly requests saw fit to make a breaking update, but it could not verify the old certificate with the common name (cn) alone. I had to add subject alt name.

The stack traces were partially obscured by being within a parameterised callback function, which could be removed and was probably legacy from when we could monitor mining rigs. Removing this prompted a whole lot of refactoring.